### PR TITLE
chore: run GitHub Actions on rh-ubuntu-latest-2core runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: rh-ubuntu-latest-2core
 
     name: Publish to NPM
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     # by the push to the branch.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-latest
+    runs-on: rh-ubuntu-latest-2core
 
     name: Test
 


### PR DESCRIPTION
Switch `runs-on: ubuntu-latest` → `rh-ubuntu-latest-2core` (self-hosted runner). CI-config housekeeping, no code paths.